### PR TITLE
feat: 1537 add swagger docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,9 @@ Start the development server: `npm run dev`
 ## Env
 
 According to .env.template.
+
+## Swagger
+
+We utilize `koa2-swagger-ui` and `swagger-jsdoc` for documenting our API. Each endpoint is required to have appropriate
+JSDoc comments and tags for comprehensive documentation. The Swagger document is exposed on `/swagger`.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "@iteam/config": "^12.1.2",
         "@koa/cors": "^5.0.0",
         "@koa/router": "^12.0.1",
+        "@types/swagger-jsdoc": "^6.0.4",
+        "@types/swagger-ui": "^3.52.4",
         "axios": "^1.6.5",
         "dotenv": "^16.3.2",
         "easy-soap-request": "^5.6.1",
@@ -21,8 +23,10 @@
         "koa-body": "^6.0.1",
         "koa-bodyparser": "^4.4.1",
         "koa-pino-logger": "^4.0.0",
+        "koa2-swagger-ui": "^5.10.0",
         "onecore-types": "^1.18.0",
         "onecore-utilities": "^1.0.2",
+        "swagger-jsdoc": "^6.2.8",
         "tedious": "^16.6.1"
       },
       "devDependencies": {
@@ -70,6 +74,46 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -1602,6 +1646,11 @@
       "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.6.1.tgz",
       "integrity": "sha512-Xla/d7ZMMR6+zRd6lTio0wRZECfcfFJP7GGe9A9L4tDOlD5CX4YcZ4YZle9w58bBYzssojVapI84RraKWDQZRg=="
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+    },
     "node_modules/@koa/cors": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-5.0.0.tgz",
@@ -2077,8 +2126,7 @@
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -2287,6 +2335,16 @@
       "dependencies": {
         "@types/superagent": "*"
       }
+    },
+    "node_modules/@types/swagger-jsdoc": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/swagger-jsdoc/-/swagger-jsdoc-6.0.4.tgz",
+      "integrity": "sha512-W+Xw5epcOZrF/AooUM/PccNMSAFOKWZA5dasNyMujTwsBkU74njSJBpvCCJhHAJ95XRMzQrrW844Btu0uoetwQ=="
+    },
+    "node_modules/@types/swagger-ui": {
+      "version": "3.52.4",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui/-/swagger-ui-3.52.4.tgz",
+      "integrity": "sha512-7NV7q8BfupqdQxr26OkM0g0YEPB9uXnKGzXadgcearvI9MoCHt3F72lPTX3fZZIlrr21DC0IK26wcDMZ37oFDA=="
     },
     "node_modules/@types/unist": {
       "version": "2.0.10",
@@ -3326,6 +3384,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -4031,7 +4094,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -7130,6 +7192,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/koa2-swagger-ui": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/koa2-swagger-ui/-/koa2-swagger-ui-5.10.0.tgz",
+      "integrity": "sha512-UEktDUyWP5BvBB8glVWHN14246IH6WZC8sryONC+v9Rm6FA3/8V+CgXpRuHkAEy0KntMwp2sJ5CutTu6ODtC3w==",
+      "dependencies": {
+        "handlebars": "^4.7.8",
+        "lodash": "^4.17.21",
+        "read-pkg-up": "7.0.1"
+      },
+      "peerDependencies": {
+        "@types/koa": "*"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -7177,6 +7252,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -7186,6 +7266,11 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
@@ -7223,6 +7308,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
@@ -7943,6 +8033,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "peer": true
     },
     "node_modules/optionator": {
       "version": "0.9.3",
@@ -9454,6 +9550,92 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "dependencies": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/tarn": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.2.tgz",
@@ -10086,6 +10268,14 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -10297,6 +10487,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "@iteam/config": "^12.1.2",
     "@koa/cors": "^5.0.0",
     "@koa/router": "^12.0.1",
+    "@types/swagger-jsdoc": "^6.0.4",
+    "@types/swagger-ui": "^3.52.4",
     "axios": "^1.6.5",
     "dotenv": "^16.3.2",
     "easy-soap-request": "^5.6.1",
@@ -54,8 +56,10 @@
     "koa-body": "^6.0.1",
     "koa-bodyparser": "^4.4.1",
     "koa-pino-logger": "^4.0.0",
+    "koa2-swagger-ui": "^5.10.0",
     "onecore-types": "^1.18.0",
     "onecore-utilities": "^1.0.2",
+    "swagger-jsdoc": "^6.2.8",
     "tedious": "^16.6.1"
   }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,10 +1,12 @@
 import KoaRouter from '@koa/router'
 import { routes as propertyInfoRoutes } from './services/property-info-service'
 import { routes as healthRoutes } from './services/health-service'
+import { routes as swagggerRoutes } from './services/swagger'
 
 const router = new KoaRouter()
 
-propertyInfoRoutes(router)
 healthRoutes(router)
+propertyInfoRoutes(router)
+swagggerRoutes(router)
 
 export default router

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,10 +5,20 @@ import cors from '@koa/cors'
 import api from './api'
 import errorHandler from './middlewares/error-handler'
 import { logger, loggerMiddlewares } from 'onecore-utilities'
+import { koaSwagger } from 'koa2-swagger-ui'
 
 const app = new Koa()
 
 app.use(cors())
+
+app.use(
+  koaSwagger({
+    routePrefix: '/swagger',
+    swaggerOptions: {
+      url: '/swagger.json',
+    },
+  })
+)
 
 app.on('error', (err) => {
   logger.error(err)

--- a/src/services/health-service/index.ts
+++ b/src/services/health-service/index.ts
@@ -51,7 +51,54 @@ const subsystems = [
   },
 ]
 
+/**
+ * @swagger
+ * openapi: 3.0.0
+ * tags:
+ *   - name: Health
+ *     description: Operations related to service health
+ */
 export const routes = (router: KoaRouter) => {
+  /**
+   * @swagger
+   * /health:
+   *   get:
+   *     summary: Check system health status
+   *     tags:
+   *       - Health
+   *     description: Retrieves the health status of the system and its subsystems.
+   *     responses:
+   *       '200':
+   *         description: Successful response with system health status
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 name:
+   *                   type: string
+   *                   example: core
+   *                   description: Name of the system.
+   *                 status:
+   *                   type: string
+   *                   example: active
+   *                   description: Overall status of the system ('active', 'impaired', 'failure', 'unknown').
+   *                 subsystems:
+   *                   type: array
+   *                   items:
+   *                     type: object
+   *                     properties:
+   *                       name:
+   *                         type: string
+   *                         description: Name of the subsystem.
+   *                       status:
+   *                         type: string
+   *                         enum: ['active', 'impaired', 'failure', 'unknown']
+   *                         description: Status of the subsystem.
+   *                       details:
+   *                         type: string
+   *                         description: Additional details about the subsystem status.
+   */
   router.get('(.*)/health', async (ctx) => {
     const health: SystemHealth = {
       name: 'property-management',

--- a/src/services/property-info-service/index.ts
+++ b/src/services/property-info-service/index.ts
@@ -36,7 +36,38 @@ import { getPublishedParkingSpaceFromSoapService } from './adapters/xpand-soap-a
  * The routes of this service are exported as the routes object. The service can also have
  * other exports (named or default) to provide externally usable helper functions, types etc.
  */
+
+/**
+ * @swagger
+ * openapi: 3.0.0
+ * tags:
+ *   - name: Property management
+ *     description: Operations related to property management
+ */
 export const routes = (router: KoaRouter) => {
+  /**
+   * @swagger
+   * /rentalproperties/{id}/material-options:
+   *   get:
+   *     summary: Get room types with material options by rental property ID
+   *     tags:
+   *       - Property management
+   *     description: Retrieve room types along with their material options for a specified rental property ID.
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: ID of the rental property to fetch room types and material options for.
+   *     responses:
+   *       '200':
+   *         description: Successful response with room types and their material options.
+   *         content:
+   *          application/json:
+   *             schema:
+   *               type: object
+   */
   router.get('(.*)/rentalproperties/:id/material-options', async (ctx) => {
     const roomTypes = await getRoomTypes(ctx.params.id)
     const materialOptions = await getRoomTypeWithMaterialOptions(roomTypes)
@@ -46,6 +77,35 @@ export const routes = (router: KoaRouter) => {
     }
   })
 
+  /**
+   * @swagger
+   * /rentalproperties/{id}/material-options/{materialOptionId}:
+   *   get:
+   *     summary: Get material option by ID for a specific rental property
+   *     tags:
+   *      - Property management
+   *     description: Retrieve a specific material option for a rental property by its ID and the material option ID.
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: ID of the rental property to fetch material options from.
+   *       - in: path
+   *         name: materialOptionId
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: ID of the material option to fetch.
+   *     responses:
+   *       '200':
+   *         description: Successful response with the requested material option.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   */
   router.get(
     '(.*)/rentalproperties/:id/material-options/:materialOptionId',
     async (ctx) => {
@@ -54,6 +114,34 @@ export const routes = (router: KoaRouter) => {
     }
   )
 
+  /**
+   * @swagger
+   * /rentalproperties/{id}/rooms-with-material-choices:
+   *   get:
+   *     summary: Get rooms with material choices for a specific rental property
+   *     tags:
+   *       -  Property management
+   *     description: Retrieve rooms with their associated material choices for a rental property identified by {id}.
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: ID of the rental property to fetch rooms with material choices for.
+   *     responses:
+   *       '200':
+   *         description: Successful response with the requested rooms and their material choices.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 roomTypes:
+   *                   type: array
+   *                   items:
+   *                     type: object
+   */
   router.get(
     '(.*)/rentalproperties/:id/rooms-with-material-choices',
     async (ctx) => {
@@ -75,6 +163,34 @@ export const routes = (router: KoaRouter) => {
     }
   )
 
+  /**
+   * @swagger
+   * /rentalproperties/{id}/material-choices:
+   *   get:
+   *     summary: Get material choices for a specific rental property
+   *     tags:
+   *       -  Property management
+   *     description: Retrieve material choices associated with a rental property identified by {id}.
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: ID of the rental property to fetch material choices for.
+   *     responses:
+   *       '200':
+   *         description: Successful response with the requested material choices
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 materialChoices:
+   *                   type: array
+   *                   items:
+   *                     type: object
+   */
   router.get('(.*)/rentalproperties/:id/material-choices', async (ctx) => {
     const apartmentId = ctx.params.id
     const materialChoices = await getMaterialChoicesByApartmentId(apartmentId)
@@ -82,6 +198,40 @@ export const routes = (router: KoaRouter) => {
     ctx.body = { materialChoices: materialChoices }
   })
 
+  /**
+   * @swagger
+   * /rentalproperties/{apartmentId}/{contractId}/material-choices:
+   *   get:
+   *     summary: Get material choices for a specific apartment and contract
+   *     tags:
+   *       - Property management
+   *     description: Retrieve material choices associated with a specific apartment and contract identified by {apartmentId} and {contractId}.
+   *     parameters:
+   *       - in: path
+   *         name: apartmentId
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: ID of the apartment to fetch material choices for.
+   *       - in: path
+   *         name: contractId
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: ID of the contract to fetch material choices for.
+   *     responses:
+   *       '200':
+   *         description: Successful response with the requested material choices
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 materialChoices:
+   *                   type: array
+   *                   items:
+   *                     type: object
+   */
   router.get(
     '(.*)/rentalproperties/:apartmentId/:contractId/material-choices',
     async (ctx) => {
@@ -92,7 +242,32 @@ export const routes = (router: KoaRouter) => {
     }
   )
 
-  // ?submitted=true|false
+  /**
+   * @swagger
+   * /rentalproperties/material-choice-statuses:
+   *   get:
+   *     summary: Get material choice statuses for rental properties
+   *     tags:
+   *       - Property management
+   *     description: Retrieve the statuses of material choices associated with rental properties.
+   *     parameters:
+   *       - in: query
+   *         name: projectCode
+   *         required: false
+   *         schema:
+   *           type: string
+   *         description: Optional project code to filter the material choice statuses.
+   *     responses:
+   *       '200':
+   *         description: Successful response with the material choice statuses
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: array
+   *               items:
+   *                 type: object
+   */
+
   router.get('(.*)/rentalproperties/material-choice-statuses', async (ctx) => {
     const apartmentChoiceStatuses = await getApartmentMaterialChoiceStatuses(
       ctx.params.projectCode
@@ -101,6 +276,40 @@ export const routes = (router: KoaRouter) => {
     ctx.body = apartmentChoiceStatuses
   })
 
+  /**
+   * @swagger
+   * /rentalproperties/{id}/material-choices:
+   *   post:
+   *     summary: Save material choices for a specific rental property
+   *     tags:
+   *       - Property management
+   *     description: Save the material choices associated with a rental property identified by {id}.
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: ID of the rental property to save material choices for.
+   *     requestBody:
+   *       description: Array of material choices to be saved
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: array
+   *             items:
+   *               type: object
+   *     responses:
+   *       '200':
+   *         description: Successful response with the saved material choices
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: array
+   *               items:
+   *                 type: object
+   */
   router.post('(.*)/rentalproperties/:id/material-choices', async (ctx) => {
     const result = await saveMaterialChoices(
       ctx.params.id,
@@ -109,17 +318,156 @@ export const routes = (router: KoaRouter) => {
     ctx.body = result
   })
 
+  /**
+   * @swagger
+   * /rentalproperties/{id}:
+   *   get:
+   *     summary: Get rental property details by ID
+   *     tags:
+   *       -  Property management
+   *     description: Retrieve the details of a rental property identified by {id}.
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: ID of the rental property to fetch details for.
+   *     responses:
+   *       '200':
+   *         description: Successfully retrieved rental property details
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   */
+
   router.get('(.*)/rentalproperties/:id', async (ctx) => {
     const responseData = await getRentalProperty(ctx.params.id)
 
     ctx.body = responseData
   })
+  /**
+   * @swagger
+   * /parkingspaces/{id}:
+   *   get:
+   *     summary: Get parking space details by ID
+   *     tags:
+   *       - Property management
+   *     description: Retrieve the details of a parking space identified by {id}.
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: ID of the parking space to fetch details for.
+   *     responses:
+   *       '200':
+   *         description: Successfully retrieved parking space details
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   */
   //todo: refactor the subsequent requests to use same data source (use soap service instead of mimer.nu api)
   router.get('(.*)/parkingspaces/:id', async (ctx) => {
     const responseData = await getParkingSpace(ctx.params.id)
 
     ctx.body = responseData
   })
+
+  /**
+   * @swagger
+   * /publishedParkingSpaces/{id}:
+   *   get:
+   *     summary: Get published parking space details by ID
+   *     tags:
+   *       - Property management
+   *     description: Retrieve the details of a published parking space identified by {id} from the SOAP service.
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: ID of the published parking space to fetch details for.
+   *     responses:
+   *       '200':
+   *         description: Successfully retrieved published parking space details
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 id:
+   *                   type: integer
+   *                   description: The ID of the listing.
+   *                   example: -1
+   *                 rentalObjectCode:
+   *                   type: string
+   *                   description: The rental object code of the parking space.
+   *                 address:
+   *                   type: string
+   *                   description: The address of the parking space.
+   *                 monthlyRent:
+   *                   type: number
+   *                   format: float
+   *                   description: The monthly rent of the parking space.
+   *                 districtCaption:
+   *                   type: string
+   *                   description: The caption of the district.
+   *                 districtCode:
+   *                   type: string
+   *                   description: The code of the district.
+   *                 blockCaption:
+   *                   type: string
+   *                   description: The caption of the block.
+   *                 blockCode:
+   *                   type: string
+   *                   description: The code of the block.
+   *                 objectTypeCaption:
+   *                   type: string
+   *                   description: The caption of the object type.
+   *                 objectTypeCode:
+   *                   type: string
+   *                   description: The code of the object type.
+   *                 rentalObjectTypeCaption:
+   *                   type: string
+   *                   description: The caption of the rental object type.
+   *                 rentalObjectTypeCode:
+   *                   type: string
+   *                   description: The code of the rental object type.
+   *                 publishedFrom:
+   *                   type: string
+   *                   format: date-time
+   *                   description: The date from which the parking space is published.
+   *                 publishedTo:
+   *                   type: string
+   *                   format: date-time
+   *                   description: The date until which the parking space is published.
+   *                 vacantFrom:
+   *                   type: string
+   *                   format: date-time
+   *                   description: The date from which the parking space is vacant.
+   *                 status:
+   *                   type: string
+   *                   description: The status of the listing.
+   *                   enum: [Active, Inactive]
+   *                 waitingListType:
+   *                   type: string
+   *                   description: The type of waiting list.
+   *       '404':
+   *         description: Published parking space not found
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 message:
+   *                   type: string
+   *                   example: "Published parking space not found"
+   */
 
   router.get('(.*)/publishedParkingSpaces/:id', async (ctx) => {
     const xpandParkingSpace = await getPublishedParkingSpaceFromSoapService(
@@ -152,10 +500,58 @@ export const routes = (router: KoaRouter) => {
     ctx.body = listing
   })
 
+  /**
+   * @swagger
+   * /rentalPropertyInfo/{id}:
+   *   get:
+   *     summary: Get rental property information by ID
+   *     tags:
+   *       - Property management
+   *     description: Retrieve detailed information about a rental property identified by {id}.
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: ID of the rental property to fetch information for.
+   *     responses:
+   *       '200':
+   *         description: Successful response with the requested rental property information
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   */
+
   router.get('(.*)/rentalPropertyInfo/:id', async (ctx) => {
     const responseData = await getRentalPropertyInfo(ctx.params.id)
     ctx.body = responseData
   })
+
+  /**
+   * @swagger
+   * /maintenanceUnits/{id}:
+   *   get:
+   *     summary: Get maintenance units by ID
+   *     tags:
+   *       - Property management
+   *     description: Retrieve maintenance units associated with a specific ID.
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: ID of the maintenance unit to fetch.
+   *     responses:
+   *       '200':
+   *         description: Successful response with the requested maintenance units
+   *         content:
+   *          application/json:
+   *             schema:
+   *               type: object
+   */
 
   router.get('(.*)/maintenanceUnits/:id', async (ctx) => {
     const responseData = await getMaintenanceUnits(ctx.params.id)

--- a/src/services/swagger/index.ts
+++ b/src/services/swagger/index.ts
@@ -6,7 +6,7 @@ export const routes = (router: KoaRouter) => {
     definition: {
       openapi: '3.0.0',
       info: {
-        title: 'onecore-leasing',
+        title: 'onecore-property-management',
         version: '1.0.0',
       },
     },

--- a/src/services/swagger/index.ts
+++ b/src/services/swagger/index.ts
@@ -1,0 +1,25 @@
+import KoaRouter from '@koa/router'
+import swaggerJsdoc from 'swagger-jsdoc'
+
+export const routes = (router: KoaRouter) => {
+  const options = {
+    definition: {
+      openapi: '3.0.0',
+      info: {
+        title: 'onecore-leasing',
+        version: '1.0.0',
+      },
+    },
+    apis: [
+      './src/services/health-service/*.ts',
+      './src/services/property-info-service/*.ts',
+    ],
+  }
+
+  const swaggerSpec = swaggerJsdoc(options)
+
+  router.get('/swagger.json', async function (ctx) {
+    ctx.set('Content-Type', 'application/json')
+    ctx.body = swaggerSpec
+  })
+}


### PR DESCRIPTION
https://dev.azure.com/mimeronline/ONECore/_boards/board/t/Dev/Issues/?workitem=1537

* adds swagger documentation exposed on /swagger

Writing jsdoc takes quite some time and the current documentation can be improved later, preferably with actual request/response types. But I think this is good first step for our api docs and will save us a lot of time. For testing this can probably replace Postman for most cases.

<img width="1384" alt="image" src="https://github.com/user-attachments/assets/6da08a85-7341-4f95-a3f8-499c7936007c">
